### PR TITLE
Add 19th and 20th plenary resolutions

### DIFF
--- a/plenary/plenary-19.yaml
+++ b/plenary/plenary-19.yaml
@@ -113,11 +113,11 @@ resolutions:
       - type: resolves
         date_effective: 2002-09-06
         message: |
-        ISO/TC 154 resolves to set up a Task Force to process the substantive comments in a subsequent revision of ISO 8601, "Representation of dates and times".
+          ISO/TC 154 resolves to set up a Task Force to process the substantive comments in a subsequent revision of ISO 8601, "Representation of dates and times".
 
-        The task force members are: Mr Vuilleumier (SNV, CH, Convener), Mr Visser (NEN, NL), Mr Crowley (US), Mr Itoh (JISC, JP), Mr Boesler (DIN, DE) and Mr Bezos (ISO/TC 184 liaison).
+          The task force members are: Mr Vuilleumier (SNV, CH, Convener), Mr Visser (NEN, NL), Mr Crowley (US), Mr Itoh (JISC, JP), Mr Boesler (DIN, DE) and Mr Bezos (ISO/TC 184 liaison).
 
-        The TF Convener shall report back to the ISO/TC 154 before end of 2002.
+          The TF Convener shall report back to the ISO/TC 154 before end of 2002.
 
 
   - dates:
@@ -181,7 +181,8 @@ resolutions:
     actions:
       - type: requests
         date_effective: 2002-09-06
-        message: ISO/TC 154 resolves, in line with ISO7372MA resolution 2 (see document 154 N 420), to request its WG 1 contact other "standardisation bodies or consortia" in order to know if they want to bring their data and participate to the analysis and comparison with other directories contained in the multilingual semantic tool developed during the BSR project. Examples of such bodies are: CEFACT Forum, OASIS, SWIFT, ISO/TC 68, ISO/TC 184. The WG 1 shall report to TC 154 at its next meeting.
+        message: |
+          ISO/TC 154 resolves, in line with ISO7372MA resolution 2 (see document 154 N 420), to request its WG 1 contact other "standardisation bodies or consortia" in order to know if they want to bring their data and participate to the analysis and comparison with other directories contained in the multilingual semantic tool developed during the BSR project. Examples of such bodies are: CEFACT Forum, OASIS, SWIFT, ISO/TC 68, ISO/TC 184. The WG 1 shall report to TC 154 at its next meeting.
 
 
   - dates:
@@ -197,7 +198,8 @@ resolutions:
     actions:
       - type: agrees
         date_effective: 2002-09-06
-        message: ISO/TC 154, taking account of changes in semantic registers development, agrees to the WG 1 request to change its name to: "Semantic engine", in order to provide a better visibility on this part of its work. The objective of the WG 1 remains: "to act as a central reference to assist in the universal, multilingual understanding of data across commerce, industry and administration" (TC 154 resolution 159: see doc. 154n303).
+        message: |
+          ISO/TC 154, taking account of changes in semantic registers development, agrees to the WG 1 request to change its name to: "Semantic engine", in order to provide a better visibility on this part of its work. The objective of the WG 1 remains: "to act as a central reference to assist in the universal, multilingual understanding of data across commerce, industry and administration" (TC 154 resolution 159: see doc. 154n303).
 
 
   - dates:

--- a/plenary/plenary-19.yaml
+++ b/plenary/plenary-19.yaml
@@ -147,7 +147,7 @@ resolutions:
         message: Unanimous
 
     actions:
-      - type: chairs
+      - type: resolves
         date_effective: 2002-09-06
         message: ISO/TC 154 Chair to take note that the next ISO 11180, "Postal addressing", systematic review will take place in 2003.
 
@@ -163,7 +163,7 @@ resolutions:
         message: Unanimous
 
     actions:
-      - type: chairs
+      - type: resolves
         date_effective: 2002-09-06
         message: ISO/TC 154 Chair to take note that the next ISO TS 16668, "BSR", systematic review will take place in 2003.
 

--- a/plenary/plenary-19.yaml
+++ b/plenary/plenary-19.yaml
@@ -1,0 +1,295 @@
+metadata:
+  title: Resolutions and action items of the ISO/TC 154 19th meeting
+  date: 2002-09-06
+  source: ISO/TC 154
+resolutions:
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 212
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to migrate the existing liaisons with the EWG and CDWG to the UN/CEFACT Forum, and requests the ISO/TC154 Chair to contact the Forum Coordination Team to secure this migration.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 213
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: thanks
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to thank JSWG for the successful revision of ISO 9735 and for the publication facilities that provide access to these documents. In particular TC 154 resolves to thank Bernd Boesler and Henry Schlieper for providing excellent and efficient hosting facilities for the JSWG web-site.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 214
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: establishes
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to establish a liaison with CEN/ISSS WS EC and WS eBES.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 215
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: establishes
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to establish a liaison with ISO/TC 204 and to express interest in being a party to their MoU on "Standards development for freight movement within the supply chain".
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 216
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: estabilishes
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to establish a liaison with ISO/TC 46/SC 11.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 217
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to discontinue its liaison with ISO/TC 10, relying on good advice coming from ISO/TC 184.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 218
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 2002-09-06
+        message: |
+        ISO/TC 154 resolves to set up a Task Force to process the substantive comments in a subsequent revision of ISO 8601, "Representation of dates and times".
+
+        The task force members are: Mr Vuilleumier (SNV, CH, Convener), Mr Visser (NEN, NL), Mr Crowley (US), Mr Itoh (JISC, JP), Mr Boesler (DIN, DE) and Mr Bezos (ISO/TC 184 liaison).
+
+        The TF Convener shall report back to the ISO/TC 154 before end of 2002.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 219
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: identifies
+        date_effective: 2002-09-06
+        message: ISO/TC 154 identifies ISO/FDIS 18513, "Tourism services – Hotels and other types of tourism accommodation - Terminolgy", as an interesting document.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 12
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: chairs
+        date_effective: 2002-09-06
+        message: ISO/TC 154 Chair to take note that the next ISO 11180, "Postal addressing", systematic review will take place in 2003.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 13
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: chairs
+        date_effective: 2002-09-06
+        message: ISO/TC 154 Chair to take note that the next ISO TS 16668, "BSR", systematic review will take place in 2003.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 220
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: requests
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves, in line with ISO7372MA resolution 2 (see document 154 N 420), to request its WG 1 contact other "standardisation bodies or consortia" in order to know if they want to bring their data and participate to the analysis and comparison with other directories contained in the multilingual semantic tool developed during the BSR project. Examples of such bodies are: CEFACT Forum, OASIS, SWIFT, ISO/TC 68, ISO/TC 184. The WG 1 shall report to TC 154 at its next meeting.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 221
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: agrees
+        date_effective: 2002-09-06
+        message: ISO/TC 154, taking account of changes in semantic registers development, agrees to the WG 1 request to change its name to: "Semantic engine", in order to provide a better visibility on this part of its work. The objective of the WG 1 remains: "to act as a central reference to assist in the universal, multilingual understanding of data across commerce, industry and administration" (TC 154 resolution 159: see doc. 154n303).
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 14
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 2002-09-06
+        message: ISO NP 22208 Project Leader to provide the CD, for processing ballot.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 222
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: endorses
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to endorse the resolutions and action items adopted by the ISO7372MA and ISO/TC 154/WG 1 documented in document 154 N 420.
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 223
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to hold its next meeting together with the ISO7372MA and ISO/TC 154/WG 1 back to back before the next UN/CEFACT Forum, subject to a decision on the date and place of the forum being made by end of 2002-09. Should a decision on the Forum date not being available in time, TC 154 Chair will secure an alternative.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 224
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: thanks
+        date_effective: 2002-09-06
+        message: ISO/TC154 resolves to thank Margaret Pemberton, SAI/AU and EWG, and Henry Schlieper, DIN/DE, for their excellent contribution to the work of the ISO7372MA and also to thank Jean-Loup Commo, AFNOR/FR for the excellent and effective editing of the ISO7372MA and ISO/TC154/WG1, as well as the ISO/TC154 resolutions.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 225
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: thanks
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to thank the chair and members of WG 1 for their excellent contribution to the work of the ISO7372MA and in particular for the availability of the BSR semantic engine.
+
+
+  - dates:
+      - 2002-09-06
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 226
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: thanks
+        date_effective: 2002-09-06
+        message: ISO/TC 154 resolves to thank the Direction du III e arrondissement, Geneva, of the Swiss Customs Administration for providing excellent and efficient hosting facilities for this meeting and in particular to thank François Vuilleumier, SNV/CH and ISO/TC 154 Chair for planning and facilitation.

--- a/plenary/plenary-20.yaml
+++ b/plenary/plenary-20.yaml
@@ -1,0 +1,328 @@
+metadata:
+  title: Resolutions and action items of the ISO/TC 154 20th meeting
+  date: 2003-03-07
+  source: ISO/TC 154
+resolutions:
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 227
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: thanks
+        date_effective: 2003-03-07
+        message: ISO/TC 154 resolves to thank the ISO/TC 37 for contributing of their liaison report (see doc. 154n435).
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 228
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: thanks
+        date_effective: 2003-03-07
+        message: ISO/TC154 are very grateful to Andrew Schoka for providing the group with an introduction to the past, present and future work plans of TC204. Andrew described TC204’s new Work Item, NP24533, entitled "Data Dictionary and Message Set to Facilitate the Movement of Freight and its Intermodal Transfer - Road Transport Information Interchanges". He reported that liaisons have been established with key organisations e.g. UN/CEFACT. At a recent meeting of ISO TC204 WG7.2 it was recognised that collaboration was an important element of this project. It appears that there are areas of potential overlap that need urgent investigation, creating opportunities for harmonisation. Particular areas include (a) methodology - UN/CEFACT-ebXML CCTS, (b) data element naming and defining - the ISO 7372 (UNTDED) MA and the several UN/CEFACT TBG domain BP modelling and CC definition projects. These include work in the supply chain related domain groups TBG1 (Materials Management), TBG2 (Procurement), TBG3 (Transport & Logistics), TBG4 (Customs), & TBG5 (Finance).
+
+      - type: recognises
+        date_effective: 2003-03-07
+        message: TC154 recognises that there exists a tangible opportunity for crucial convergence between the TC204 ISO 14817 and the UN/CEFACT-ebXML CCTS. In order to promote and secure this much needed convergence, TC154 resolves to support and strengthen liaison between the 7372MA activity, the UN/CEFACT Forum, and TC204 to achieve this goal.
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 229
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: welcomes
+        date_effective: 2003-03-07
+        message: The ISO TC 154 Plenary resolves to welcome the Bank for International Settlements (BIS) as an external Class A Liaison. In addition, the Plenary compliments Mr. Stuart Feder on his past excellent work as a facilitator and peacemaker in many organizational situations and looks forward to working with him in the future.
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 230
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: requests
+        date_effective: 2003-03-07
+        message: |
+        ISO/TC154 requests the ISO8601 Expert (Editing) Group to consolidate all comments received to date into a table, updating document 8601RevN007.
+
+        The Group will make an initial ranking into categories of:
+
+        1. 'will implement' on e.g. typographical errors, obvious improvements,
+
+        2. 'will not implement' on comments that are counter-productive,
+
+        3. 'for wider discussion' when opinions from all TC154 participants are valuable, updating document 8601RevN002r1.
+
+        These two papers will be distributed by the Expert (Editing) Group to TC154 membership, seeking confirmation of categories 1 and 2, and further input on category 3.
+
+        Distribution is anticipated by end May, and feedback would be required by end July. It is anticipated that a revised ISO 8601 could be distributed for the CD ballot in August.
+
+      - type: empowers
+        date_effective: 2003-03-07
+        message: TC154 empowers the expert group to ask the ISO/TC154 Secretary to launch the revised 8601 CD ballot when the expert group feels ready to do so.
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 15
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 2003-03-07
+        message: Japanese delegation (Kenji Itoh) to check with ISO 8601 editor (Louis Visser) concerning the status of the ISO 8601:2000 Corrigendum based on the Japanese contribution. This draft Corrigendum shall not be issued as such, but fed into the ISO8601 Revision (see Resolution 230 above).
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 231
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: request
+        date_effective: 2003-03-07
+        message: |
+        Based on the request below, ISO TC 154 resolves to withdraw the ballot on DTS15000.
+
+        Date: Tue, 04 Mar 2003 01:35:05 +0100
+
+        To: "TC154-P List" <tc154-p@list.unicc.org>
+
+        From: Francois Vuilleumier <fvuille@attglobal.net>
+
+        Subject: [TC154-P:253] Fwd: JCC request to withdraw ebXML ballot [DTS15000]
+
+        to ISO/TC154, for our plenary meeting, Friday this week. all the best, François
+
+        Date: Tue, 25 Feb 2003 11:00:06 -0800
+        
+        To: <smith@iso.org>
+        
+        From: James Bryce Clark <jbc@lawyer.com>
+        
+        Subject: JCC request to withdraw ebXML ballot
+
+        Cc: <raywalker@attglobal.net>,<knaujok@attglobal.net>, <patrick.gannon@oasis-open.org>,<simon.nicholson@sun.com>,<karl.best@oasis-open.org>,<clivio@iso.org>,<fvuille@attglobal.net>
+
+        Dear Mike:
+
+        This will confirm that UN/CEFACT and OASIS wish to have the pending TC154 ballot withdrawn. We believe it was launched in error, as our internal reviews were not completed. It is important to our constituents to adhere to our processes.
+
+        This withdrawal is without prejudice to our ongoing consultations regarding the options for further promoting ebXML standards, which include working with ISO. Both of our organizations value our cooperative relationship with ISO.
+
+        We also wish to thank you personally for taking the time to clarify the applicable rules and options. Your January 22nd explanation and our January 30th conference call were very helpful, and your insights will assist in our deliberations.
+
+        If there is any further action needed by ISOCS to confirm the wishes of the specification owners, please advise us.
+
+        Best regards - Jamie Clark - Chair, ebXML Joint Coordinating Committee
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 16
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: chairs
+        date_effective: 2003-03-07
+        message: ISO/TC154 Chair to make the necessary steps to withdraw the DTS15000 ballot.
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 232
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: acknowledges
+        date_effective: 2003-03-07
+        message: |
+        ISO/TC154 acknowledges receipt of the ISO/IEC JTC1/SC32 comments (see document 154n441). Thank you for your contribution.
+
+        Reminder:
+
+        From: Clivio Sophie
+
+        To: Douglas Mann; Bruce Bargmeyer; Keith Brannon
+
+        Cc: Michael Smith; Francois Vuilleumier; Patricia Bartels; Karl Best
+
+        Sent: Monday, January 06, 2003 10:39 AM
+
+        Subject: Eb-XML specifications under ISO approval in ISO TC154-JTC1 participation
+
+        Dear Doug and Bruce,
+
+        OASIS and UN/CEFACT are now submitting their eb-XML specifications for approval as ISO TS (Technical specifications) in ISO TC154. 6 out of the 8 eb-XML parts will be submitted as a first package, the 2 others (part 2 and 8) will come later, when completed.
+
+        Given that 2/3 of the eb-XML specs are of direct relevance to TC154 (within TC154 scope), it has been agreed that the eb-XML specs would be hosted by TC154 with the creation of a new (virtual) joint WG (under TC154 lead) involving the JTC1 SCs concerned ( mainly SC32) in order to involve the JTC1 expertise in the process.
+
+        The ballot on the 6 first Technical specifications will be launched by ISO TC154 in the next few days, under the generic title ISO TS 15000: "Electronic Business eXtensible Mark-up Language (ebXML) parts 1,3,4,5,6 and 7", and we would ask JTC1 SC32 to comment on the various parts (specifications) when they are of direct relevance to your subcommittee and to nominate expert(s) if needed, to discuss the potential comments with the parties involved.
+
+        François Vuilleumier as TC154 Chair and secretary will contact you ASAP to set up the process.
+
+        [...]
+
+        Should you need any further information, do not hesitate to contact me or François directly or Keith Brannon at ISOCS. Keith will contact Lisa for securing the JTC1 participation
+
+        Kind regards and Happy New Year - Sophie
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 233
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: endorses
+        date_effective: 2003-03-07
+        message: ISO/TC 154 resolves to endorse the resolutions and action items adopted by the ISO7372MA and ISO/TC 154/WG 1 documented in document 154 N 436 Rev.1 + 440.
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 234
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: thanks
+        date_effective: 2003-03-07
+        message: ISO/TC 154 thanks Mrs. Melitta Rafelt for the excellent technical service she has provided for updating the JSWG (ISO9735) web page.
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 235
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: secures
+        date_effective: 2003-03-07
+        message: ISO/TC 154 resolves to secure the relevant prolongation of ISO/TS16668.
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 17
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: secures
+        date_effective: 2003-03-07
+        message: ISO/TC 154/WG1 Secretariat to secure the proper steps for the ISO/TS16668 ISO systematic review taking place in 2003.
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 236
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: thanks
+        date_effective: 2003-03-07
+        message: ISO/TC 154 thanks Mr. Francois Vuilleumier for his wise and efficient chairmanship.
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 237
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: thanks
+        date_effective: 2003-03-07
+        message: ISO/TC 154 thanks DISA for hosting the meetings of this week. In particular, ISO/TC154 thanks Mrs. Yvonne Meding for her excellent work serving as host and secretariat for the ISO 7372 MA and ISO TC 154 Plenary meetings.
+
+
+
+  - dates:
+      - 2003-03-07
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    identifier: 238
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 2003-03-07
+        message: Accepting with many Thanks the very kind offer made by KR/KATS, ISO/TC 154 resolves to hold its next meeting together with the ISO7372MA and ISO/TC 154/WG 1 back to back before the next UN/CEFACT Forum, 2003-09-10/12 in Seoul, hosted by KATS.
+

--- a/plenary/plenary-20.yaml
+++ b/plenary/plenary-20.yaml
@@ -69,19 +69,19 @@ resolutions:
       - type: requests
         date_effective: 2003-03-07
         message: |
-        ISO/TC154 requests the ISO8601 Expert (Editing) Group to consolidate all comments received to date into a table, updating document 8601RevN007.
+          ISO/TC154 requests the ISO8601 Expert (Editing) Group to consolidate all comments received to date into a table, updating document 8601RevN007.
 
-        The Group will make an initial ranking into categories of:
+          The Group will make an initial ranking into categories of:
 
-        1. 'will implement' on e.g. typographical errors, obvious improvements,
+          1. 'will implement' on e.g. typographical errors, obvious improvements,
 
-        2. 'will not implement' on comments that are counter-productive,
+          2. 'will not implement' on comments that are counter-productive,
 
-        3. 'for wider discussion' when opinions from all TC154 participants are valuable, updating document 8601RevN002r1.
+          3. 'for wider discussion' when opinions from all TC154 participants are valuable, updating document 8601RevN002r1.
 
-        These two papers will be distributed by the Expert (Editing) Group to TC154 membership, seeking confirmation of categories 1 and 2, and further input on category 3.
+          These two papers will be distributed by the Expert (Editing) Group to TC154 membership, seeking confirmation of categories 1 and 2, and further input on category 3.
 
-        Distribution is anticipated by end May, and feedback would be required by end July. It is anticipated that a revised ISO 8601 could be distributed for the CD ballot in August.
+          Distribution is anticipated by end May, and feedback would be required by end July. It is anticipated that a revised ISO 8601 could be distributed for the CD ballot in August.
 
       - type: empowers
         date_effective: 2003-03-07
@@ -118,39 +118,39 @@ resolutions:
       - type: request
         date_effective: 2003-03-07
         message: |
-        Based on the request below, ISO TC 154 resolves to withdraw the ballot on DTS15000.
+          Based on the request below, ISO TC 154 resolves to withdraw the ballot on DTS15000.
 
-        Date: Tue, 04 Mar 2003 01:35:05 +0100
+          Date: Tue, 04 Mar 2003 01:35:05 +0100
 
-        To: "TC154-P List" <tc154-p@list.unicc.org>
+          To: "TC154-P List" <tc154-p@list.unicc.org>
 
-        From: Francois Vuilleumier <fvuille@attglobal.net>
+          From: Francois Vuilleumier <fvuille@attglobal.net>
 
-        Subject: [TC154-P:253] Fwd: JCC request to withdraw ebXML ballot [DTS15000]
+          Subject: [TC154-P:253] Fwd: JCC request to withdraw ebXML ballot [DTS15000]
 
-        to ISO/TC154, for our plenary meeting, Friday this week. all the best, François
+          to ISO/TC154, for our plenary meeting, Friday this week. all the best, François
 
-        Date: Tue, 25 Feb 2003 11:00:06 -0800
-        
-        To: <smith@iso.org>
-        
-        From: James Bryce Clark <jbc@lawyer.com>
-        
-        Subject: JCC request to withdraw ebXML ballot
+          Date: Tue, 25 Feb 2003 11:00:06 -0800
 
-        Cc: <raywalker@attglobal.net>,<knaujok@attglobal.net>, <patrick.gannon@oasis-open.org>,<simon.nicholson@sun.com>,<karl.best@oasis-open.org>,<clivio@iso.org>,<fvuille@attglobal.net>
+          To: <smith@iso.org>
 
-        Dear Mike:
+          From: James Bryce Clark <jbc@lawyer.com>
 
-        This will confirm that UN/CEFACT and OASIS wish to have the pending TC154 ballot withdrawn. We believe it was launched in error, as our internal reviews were not completed. It is important to our constituents to adhere to our processes.
+          Subject: JCC request to withdraw ebXML ballot
 
-        This withdrawal is without prejudice to our ongoing consultations regarding the options for further promoting ebXML standards, which include working with ISO. Both of our organizations value our cooperative relationship with ISO.
+          Cc: <raywalker@attglobal.net>,<knaujok@attglobal.net>, <patrick.gannon@oasis-open.org>,<simon.nicholson@sun.com>,<karl.best@oasis-open.org>,<clivio@iso.org>,<fvuille@attglobal.net>
 
-        We also wish to thank you personally for taking the time to clarify the applicable rules and options. Your January 22nd explanation and our January 30th conference call were very helpful, and your insights will assist in our deliberations.
+          Dear Mike:
 
-        If there is any further action needed by ISOCS to confirm the wishes of the specification owners, please advise us.
+          This will confirm that UN/CEFACT and OASIS wish to have the pending TC154 ballot withdrawn. We believe it was launched in error, as our internal reviews were not completed. It is important to our constituents to adhere to our processes.
 
-        Best regards - Jamie Clark - Chair, ebXML Joint Coordinating Committee
+          This withdrawal is without prejudice to our ongoing consultations regarding the options for further promoting ebXML standards, which include working with ISO. Both of our organizations value our cooperative relationship with ISO.
+
+          We also wish to thank you personally for taking the time to clarify the applicable rules and options. Your January 22nd explanation and our January 30th conference call were very helpful, and your insights will assist in our deliberations.
+
+          If there is any further action needed by ISOCS to confirm the wishes of the specification owners, please advise us.
+
+          Best regards - Jamie Clark - Chair, ebXML Joint Coordinating Committee
 
 
   - dates:
@@ -183,35 +183,35 @@ resolutions:
       - type: acknowledges
         date_effective: 2003-03-07
         message: |
-        ISO/TC154 acknowledges receipt of the ISO/IEC JTC1/SC32 comments (see document 154n441). Thank you for your contribution.
+          ISO/TC154 acknowledges receipt of the ISO/IEC JTC1/SC32 comments (see document 154n441). Thank you for your contribution.
 
-        Reminder:
+          Reminder:
 
-        From: Clivio Sophie
+          From: Clivio Sophie
 
-        To: Douglas Mann; Bruce Bargmeyer; Keith Brannon
+          To: Douglas Mann; Bruce Bargmeyer; Keith Brannon
 
-        Cc: Michael Smith; Francois Vuilleumier; Patricia Bartels; Karl Best
+          Cc: Michael Smith; Francois Vuilleumier; Patricia Bartels; Karl Best
 
-        Sent: Monday, January 06, 2003 10:39 AM
+          Sent: Monday, January 06, 2003 10:39 AM
 
-        Subject: Eb-XML specifications under ISO approval in ISO TC154-JTC1 participation
+          Subject: Eb-XML specifications under ISO approval in ISO TC154-JTC1 participation
 
-        Dear Doug and Bruce,
+          Dear Doug and Bruce,
 
-        OASIS and UN/CEFACT are now submitting their eb-XML specifications for approval as ISO TS (Technical specifications) in ISO TC154. 6 out of the 8 eb-XML parts will be submitted as a first package, the 2 others (part 2 and 8) will come later, when completed.
+          OASIS and UN/CEFACT are now submitting their eb-XML specifications for approval as ISO TS (Technical specifications) in ISO TC154. 6 out of the 8 eb-XML parts will be submitted as a first package, the 2 others (part 2 and 8) will come later, when completed.
 
-        Given that 2/3 of the eb-XML specs are of direct relevance to TC154 (within TC154 scope), it has been agreed that the eb-XML specs would be hosted by TC154 with the creation of a new (virtual) joint WG (under TC154 lead) involving the JTC1 SCs concerned ( mainly SC32) in order to involve the JTC1 expertise in the process.
+          Given that 2/3 of the eb-XML specs are of direct relevance to TC154 (within TC154 scope), it has been agreed that the eb-XML specs would be hosted by TC154 with the creation of a new (virtual) joint WG (under TC154 lead) involving the JTC1 SCs concerned ( mainly SC32) in order to involve the JTC1 expertise in the process.
 
-        The ballot on the 6 first Technical specifications will be launched by ISO TC154 in the next few days, under the generic title ISO TS 15000: "Electronic Business eXtensible Mark-up Language (ebXML) parts 1,3,4,5,6 and 7", and we would ask JTC1 SC32 to comment on the various parts (specifications) when they are of direct relevance to your subcommittee and to nominate expert(s) if needed, to discuss the potential comments with the parties involved.
+          The ballot on the 6 first Technical specifications will be launched by ISO TC154 in the next few days, under the generic title ISO TS 15000: "Electronic Business eXtensible Mark-up Language (ebXML) parts 1,3,4,5,6 and 7", and we would ask JTC1 SC32 to comment on the various parts (specifications) when they are of direct relevance to your subcommittee and to nominate expert(s) if needed, to discuss the potential comments with the parties involved.
 
-        François Vuilleumier as TC154 Chair and secretary will contact you ASAP to set up the process.
+          François Vuilleumier as TC154 Chair and secretary will contact you ASAP to set up the process.
 
-        [...]
+          [...]
 
-        Should you need any further information, do not hesitate to contact me or François directly or Keith Brannon at ISOCS. Keith will contact Lisa for securing the JTC1 participation
+          Should you need any further information, do not hesitate to contact me or François directly or Keith Brannon at ISOCS. Keith will contact Lisa for securing the JTC1 participation
 
-        Kind regards and Happy New Year - Sophie
+          Kind regards and Happy New Year - Sophie
 
 
   - dates:


### PR DESCRIPTION
From https://github.com/iso-tc154/resolutions-data/issues/12

### Comments:

*Regarding plenary-19:*
- In resolutions 12-13, I use the word "chairs" as action type.

*Regarding plenary-20:*
- I'm not sure about the setting of resolutions 231 and 232. These include a letter attachment. For example: 

![capture-letter](https://user-images.githubusercontent.com/33627611/74769050-086e3600-5260-11ea-86d8-bcc6a98ebe1d.JPG)

(Resolution 232 is similar.) 
I included the whole letter part in the message field. Is that ok?

Thanks!

