### PR TITLE
Converted 16-18th Plenary resolutions

### DIFF
--- a/plenary/plenary-16.yaml
+++ b/plenary/plenary-16.yaml
@@ -1,0 +1,403 @@
+metadata:
+  title: Resolutions and action items of ISO/TC 154 meeting of 7-8 December 1999.
+  date: 
+    start: 1999-12-07
+    end: 1999-12-08
+  source: ISO/TC 154
+
+resolutions:
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 154-157
+
+    approvals:
+      - type: 
+        degree: 
+        message: Addressed
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    identifier: 158
+
+    approvals:
+      - type: 
+        degree: 
+        message: Addressed
+
+    actions:
+      - type: notes
+        date_effective: 1999-12-08
+        message: See resolution 175
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    identifier: 159-161
+    
+    approvals:
+      - type: 
+        degree: 
+        message: Addressed
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    identifier: 162
+    
+    approvals:
+      - type: 
+        degree: 
+        message: Addressed
+
+    actions:
+      - type: notes
+        date_effective: 1999-12-08
+        message: See resolution 174
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject:
+    identifier: 163
+
+    approvals:
+      - type:
+        degree:
+        message: Addressed
+
+    actions:
+      - type: notes
+        date_effective: 1999-12-08
+        message: ISO/TC 154 confirms this resolution and request its Chair to consult with UPU on ISO 11180 Postal addressing. See also resolution 174.
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 164-170
+
+    approvals:
+      - type:
+        degree:
+        message: Addressed
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject:
+    identifier: 171
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 1999-12-08
+        message: ISO/TC 154 resolves to grant an International Liaison A status for the International Federation of Freight Forwarders Associations (FIATA).
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject:
+    identifier: 172
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 1999-12-08
+        message: ISO/TC 154 resolves that all documents of ISO/TC 154 will only be distributed electronically from now on. A task force composed of TC 154 Chair, secretary, WG1 secretary, ISO/CS and JSWG secretary will finalize the organization of the stock of ISO TC 154 documents.
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject:
+    identifier: 173
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 1999-12-08
+        message: ISO/TC 154 resolves to hold its next meeting in the 2nd half of year 2000 in Europe.
+
+      - type: thanks
+        date_effective: 1999-12-08
+        message: ISO/TC 154 thanks CSNI (CZ) for their offer to host the meeting in Prague.
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: ISO/TC 154, identifying ISO 7372 as a key element in the set of ISO standards as listed in N324 - Suite of ISO standards around the UN Layout-Key and UNTDED, recognizing TC 154 resolutions 162 and 163 and MoU resolution 99/27, confirming the maintenance procedures of the standard as stated in ISO 7372, section 2:
+    identifier: 174
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: recognizes
+        date_effective: 1999-12-08
+        message: recognizes the need for a revision of ISO 7372, especially for aligning between paper documents and electronic documents;
+
+      - type: resolves
+        date_effective: 1999-12-08
+        message: resolves to set-up a Task Team to consult with UN/CEFACT and report back to TC 154 for decision. The team is composed as follows: BSI (S. Probert, UK), AFNOR (A. Thienot, FR), DIN (H. Hermes, DE), Chair and secretary. The team will work electronically;
+
+      - type: resolves
+        date_effective: 1999-12-08
+        message: resolves to freeze the new work item N319 – Revison of ISO 7372 – Trade data interchange – Trade data elements directory, until the Task Team reports back to TC 154.
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject:
+    identifier: 175
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 1999-12-08
+        message: ISO/TC 154 resolves that the corrections to be made to ISO 8440 to be Y2K compatible as stated in N316 – Proposal for the revision of ISO 8440 “Location of codes in trade , are a minor revision of the standard. TC 154 secretary with the Chair will prepare the changes to be sent for FDIS ballot.
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject:
+    identifier: 176
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Adopted with one abstention, FR
+
+    actions:
+      - type: resolves
+        date_effective: 1999-12-08
+        message: ISO/TC 154 resolves to revise ISO 8601 within the time frame of maximum three years, starting December 1999, with Mr. Visser (NNI, NL) as editor with the participation of SNV (CH), BSI (GB), DS (DK), CSNI (CZ).
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: ISO/TC 154 recognises the need of the users for easy implementation of ISO 9735, version 4, published in 1998/99 and therefore recommends to the Joint Syntax Working Group (JSWG):
+    identifier: 177
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: recommends
+        date_effective: 1999-12-08
+        message: to consolidate all syntax service directories` addendums of the published parts 1 to 9 of ISO 9735, version 4, and the content of the Technical Corrigendum 1 into one document to be published as a further part of ISO 9735;
+
+      - type: recommends
+        date_effective: 1999-12-08
+        message: to consolidate all definitions` addendums of the published parts 1 to 9 of ISO 9735, version 4, into one document to be published preferable together with the consolidated syntax service directories as a further part of ISO 9735;
+
+      - type: recommends
+        date_effective: 1999-12-08
+        message: to remove the information on the replacement of former syntax version as it actually reads in the Forewords of parts 1 and 2: "Together with ISO 9735-x, this part of ISO 9735 cancels and replaces ISO 9735:1988 (amended and reprinted in 1990) and Amendment 1:1992." and replace this by: "Together with ISO 9735-x, this part of ISO 9735 replaces ISO 9735:1988 (amended and reprinted in 1990) and Amendment 1:1992.";
+
+      - type: recommends
+        date_effective: 1999-12-08
+        message: to add a note in parts 1 to 9 to be re-issued and any further part of ISO 9735, version 4, stating that Syntax version 3 (ISO 9735:1988 (amended and reprinted in 1990) and Amendment 1:1992) is understood as "retained version" which is still a valid standard version and may be used further on, based on business needs.
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 178
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 1999-12-08
+        message: ISO/TC 154 resolves to create a ISO/TC 154 Chair Advisory Board, consisting of JISC (JP), BSI (GB), DIN (DE) and AFNOR (FR) to progress inter-sessional work activities. The Board will not have any decision making authority unless agreed by ISO/TC 154.
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: ISO/TC 154 considering:
+    identifier: 179
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    considerations:
+      - type: considering
+        date_effective: 1999-12-08
+        message: The results of the vote: 8 approved, 3 disapproved, 1 abstention as reported in N323 Rev.1 – Results of voting of ISO/TC 154 Draft Technical report (PDTR) 16668 “Basic
+
+      - type: considering
+        date_effective: 1999-12-08
+        message: that WG 1 took into account the comments received;
+
+      - type: considering
+        date_effective: 1999-12-08
+        message: that France changed its vote to “approved”, therefore changing the vote to 9 approved, 2 disapproved, 1 abstention;
+
+    actions:
+      - type: adopts
+        date_effective: 1999-12-08
+        message: adopts N312 – Basic Semantics Register (BSR) – Rules, Guidelines and Methodology (TS 16668) as modified by WG 1 and instructs the editor to produce a final version of this Technical Specification (TS) for publication by ISO.
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 180
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 1999-12-08
+        message: ISO/TC 154 resolves to nominate DIN (H. Hermes, DE) and BSI (S. Probert, UK) to act as TC 154 representative in the ebXML initiative and report back to ISO/TC 154.
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 181
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 1999-12-08
+        message: ISO/TC 154 resolves to initiate a new work item ballot as proposed in N315- EDIFACT Rules for the markup of UN/EDIFACT interchange structures with the eXtended Markup Langauge (XML) using Document Type Definitions (DTDs).
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 182
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: resolves
+        date_effective: 1999-12-08
+        message: ISO/TC 154 resolves to initiate a new work item ballot as proposed in N318- Rules for the operation of EDI/EC registration authorities. The start of the ballot is postponed until the final ballot document is approved by the ISO/TC 154 Chair Advisory Board.
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 183
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Unanimous
+
+    actions:
+      - type: confirms
+        date_effective: 1999-12-08
+        message: ISO/TC 154 confirms that it is open to process any documents or requests presented by UN/CEFACT relating to the UN/ECE Recommendation 20, Units of measure used in international trade
+
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 1
+
+    actions:
+      - type: notes
+        date_effective: 1999-12-08
+        message: ISO/TC 154 Chair will secure an active liaison with TC 215
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 2
+
+    approvals:
+      - type: 
+        degree: 
+        message: Closed
+
+    actions:
+      - type: notes
+        date_effective: 1999-12-08
+        message: DIN will convert the 99 work programme from PDF to DOC format
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 3
+
+    actions:
+      - type: notes
+        date_effective: 1999-12-08
+        message: ISO/TC 154 agreed that all comments to N321 – Compendium of Trade Facilitation Recommendations, should be forwarded to TC 154 Chair for him to forward them to UN/CEFACT.
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 4
+
+    actions:
+      - type: notes
+        date_effective: 1999-12-08
+        message: ISO/TC 154 WG1 secretariat will forward the results of the processing of the comments to TS 16668 to TC 154 Secretary for distribution to the P members in line with resolution 179.
+
+  - dates:
+    start: 1999-12-07
+    end: 1999-12-08
+    subject: 
+    identifier: 5
+
+    actions:
+      - type: notes
+        date_effective: 1999-12-08
+        message: ISO/TC 154 secretary will recall that when P members are voting, L and O members have a right to comment.

--- a/plenary/plenary-16.yaml
+++ b/plenary/plenary-16.yaml
@@ -1,95 +1,104 @@
 metadata:
   title: Resolutions and action items of ISO/TC 154 meeting of 7-8 December 1999.
-  date: 
+  date:
     start: 1999-12-07
     end: 1999-12-08
   source: ISO/TC 154
+  apologies:
+    - Italy
+    - US
+    - UN/CEFACT
+    - WG1 Chair
 
 resolutions:
+
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: 154-157
+  #
+  #   approvals:
+  #     - type: affirmative
+  #       degree: unanimous
+  #       message: Addressed
+  #
+  #
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: 158
+  #
+  #   approvals:
+  #     - type: affirmative
+  #       degree: unanimous
+  #       message: Addressed
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 1999-12-08
+  #       message: See resolution 175
+  #
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: 159-161
+  #
+  #   approvals:
+  #     - type: affirmative
+  #       degree: unanimous
+  #       message: Addressed
+  #
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: 162
+  #
+  #   approvals:
+  #     - type: affirmative
+  #       degree: unanimous
+  #       message: Addressed
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 1999-12-08
+  #       message: See resolution 174
+  #
+  #
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: 163
+  #
+  #   approvals:
+  #     - type:
+  #       degree:
+  #       message: Addressed
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 1999-12-08
+  #       message: ISO/TC 154 confirms this resolution and request its Chair to consult with UPU on ISO 11180 Postal addressing. See also resolution 174.
+  #
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: 164-170
+  #
+  #   approvals:
+  #     - type:
+  #       degree:
+  #       message: Addressed
+
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
-    identifier: 154-157
-
-    approvals:
-      - type: 
-        degree: 
-        message: Addressed
-
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    identifier: 158
-
-    approvals:
-      - type: 
-        degree: 
-        message: Addressed
-
-    actions:
-      - type: notes
-        date_effective: 1999-12-08
-        message: See resolution 175
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    identifier: 159-161
-    
-    approvals:
-      - type: 
-        degree: 
-        message: Addressed
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    identifier: 162
-    
-    approvals:
-      - type: 
-        degree: 
-        message: Addressed
-
-    actions:
-      - type: notes
-        date_effective: 1999-12-08
-        message: See resolution 174
-
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject:
-    identifier: 163
-
-    approvals:
-      - type:
-        degree:
-        message: Addressed
-
-    actions:
-      - type: notes
-        date_effective: 1999-12-08
-        message: ISO/TC 154 confirms this resolution and request its Chair to consult with UPU on ISO 11180 Postal addressing. See also resolution 174.
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
-    identifier: 164-170
-
-    approvals:
-      - type:
-        degree:
-        message: Addressed
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject:
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 171
 
     approvals:
@@ -104,9 +113,9 @@ resolutions:
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject:
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 172
 
     approvals:
@@ -121,9 +130,9 @@ resolutions:
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject:
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 173
 
     approvals:
@@ -142,10 +151,29 @@ resolutions:
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: ISO/TC 154, identifying ISO 7372 as a key element in the set of ISO standards as listed in N324 - Suite of ISO standards around the UN Layout-Key and UNTDED, recognizing TC 154 resolutions 162 and 163 and MoU resolution 99/27, confirming the maintenance procedures of the standard as stated in ISO 7372, section 2:
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 174
+
+    considerations:
+      - type: identifying
+        date_effective:
+          start: 1999-12-07
+          end: 1999-12-08
+        message: identifying ISO 7372 as a key element in the set of ISO standards as listed in N324 - Suite of ISO standards around the UN Layout-Key and UNTDED
+
+      - type: recognizing
+        date_effective:
+          start: 1999-12-07
+          end: 1999-12-08
+        message: recognizing TC 154 resolutions 162 and 163 and MoU resolution 99/27
+
+      - type: recognizing
+        date_effective:
+          start: 1999-12-07
+          end: 1999-12-08
+        message: confirming the maintenance procedures of the standard as stated in ISO 7372, section 2
 
     approvals:
       - type: affirmative
@@ -159,7 +187,7 @@ resolutions:
 
       - type: resolves
         date_effective: 1999-12-08
-        message: resolves to set-up a Task Team to consult with UN/CEFACT and report back to TC 154 for decision. The team is composed as follows: BSI (S. Probert, UK), AFNOR (A. Thienot, FR), DIN (H. Hermes, DE), Chair and secretary. The team will work electronically;
+        message: "resolves to set-up a Task Team to consult with UN/CEFACT and report back to TC 154 for decision. The team is composed as follows: BSI (S. Probert, UK), AFNOR (A. Thienot, FR), DIN (H. Hermes, DE), Chair and secretary. The team will work electronically;"
 
       - type: resolves
         date_effective: 1999-12-08
@@ -167,9 +195,9 @@ resolutions:
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject:
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 175
 
     approvals:
@@ -180,13 +208,13 @@ resolutions:
     actions:
       - type: resolves
         date_effective: 1999-12-08
-        message: ISO/TC 154 resolves that the corrections to be made to ISO 8440 to be Y2K compatible as stated in N316 – Proposal for the revision of ISO 8440 “Location of codes in trade , are a minor revision of the standard. TC 154 secretary with the Chair will prepare the changes to be sent for FDIS ballot.
+        message: ISO/TC 154 resolves that the corrections to be made to ISO 8440 to be Y2K compatible as stated in N316 – Proposal for the revision of ISO 8440 “Location of codes in trade", are a minor revision of the standard. TC 154 secretary with the Chair will prepare the changes to be sent for FDIS ballot.
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject:
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 176
 
     approvals:
@@ -201,10 +229,17 @@ resolutions:
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: ISO/TC 154 recognises the need of the users for easy implementation of ISO 9735, version 4, published in 1998/99 and therefore recommends to the Joint Syntax Working Group (JSWG):
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 177
+
+    considerations:
+      - type: recognises
+        date_effective:
+          start: 1999-12-07
+          end: 1999-12-08
+        message: "recognises the need of the users for easy implementation of ISO 9735, version 4, published in 1998/99 and therefore recommends to the Joint Syntax Working Group (JSWG):"
 
     approvals:
       - type: affirmative
@@ -214,7 +249,7 @@ resolutions:
     actions:
       - type: recommends
         date_effective: 1999-12-08
-        message: to consolidate all syntax service directories` addendums of the published parts 1 to 9 of ISO 9735, version 4, and the content of the Technical Corrigendum 1 into one document to be published as a further part of ISO 9735;
+        message: to consolidate all syntax service directories' addendums of the published parts 1 to 9 of ISO 9735, version 4, and the content of the Technical Corrigendum 1 into one document to be published as a further part of ISO 9735;
 
       - type: recommends
         date_effective: 1999-12-08
@@ -222,7 +257,8 @@ resolutions:
 
       - type: recommends
         date_effective: 1999-12-08
-        message: to remove the information on the replacement of former syntax version as it actually reads in the Forewords of parts 1 and 2: "Together with ISO 9735-x, this part of ISO 9735 cancels and replaces ISO 9735:1988 (amended and reprinted in 1990) and Amendment 1:1992." and replace this by: "Together with ISO 9735-x, this part of ISO 9735 replaces ISO 9735:1988 (amended and reprinted in 1990) and Amendment 1:1992.";
+        message: |
+          to remove the information on the replacement of former syntax version as it actually reads in the Forewords of parts 1 and 2: "Together with ISO 9735-x, this part of ISO 9735 cancels and replaces ISO 9735:1988 (amended and reprinted in 1990) and Amendment 1:1992." and replace this by: "Together with ISO 9735-x, this part of ISO 9735 replaces ISO 9735:1988 (amended and reprinted in 1990) and Amendment 1:1992.";
 
       - type: recommends
         date_effective: 1999-12-08
@@ -230,9 +266,9 @@ resolutions:
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 178
 
     approvals:
@@ -246,9 +282,9 @@ resolutions:
         message: ISO/TC 154 resolves to create a ISO/TC 154 Chair Advisory Board, consisting of JISC (JP), BSI (GB), DIN (DE) and AFNOR (FR) to progress inter-sessional work activities. The Board will not have any decision making authority unless agreed by ISO/TC 154.
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: ISO/TC 154 considering:
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 179
 
     approvals:
@@ -259,7 +295,7 @@ resolutions:
     considerations:
       - type: considering
         date_effective: 1999-12-08
-        message: The results of the vote: 8 approved, 3 disapproved, 1 abstention as reported in N323 Rev.1 – Results of voting of ISO/TC 154 Draft Technical report (PDTR) 16668 “Basic
+        message: "The results of the vote: 8 approved, 3 disapproved, 1 abstention as reported in N323 Rev.1 – Results of voting of ISO/TC 154 Draft Technical report (PDTR) 16668 “Basic Semantics Register”"
 
       - type: considering
         date_effective: 1999-12-08
@@ -276,9 +312,9 @@ resolutions:
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 180
 
     approvals:
@@ -292,9 +328,9 @@ resolutions:
         message: ISO/TC 154 resolves to nominate DIN (H. Hermes, DE) and BSI (S. Probert, UK) to act as TC 154 representative in the ebXML initiative and report back to ISO/TC 154.
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 181
 
     approvals:
@@ -309,9 +345,9 @@ resolutions:
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 182
 
     approvals:
@@ -326,9 +362,9 @@ resolutions:
 
 
   - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
+      start: 1999-12-07
+      end: 1999-12-08
+    subject: ISO/TC 154
     identifier: 183
 
     approvals:
@@ -342,62 +378,62 @@ resolutions:
         message: ISO/TC 154 confirms that it is open to process any documents or requests presented by UN/CEFACT relating to the UN/ECE Recommendation 20, Units of measure used in international trade
 
 
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
-    identifier: 1
-
-    actions:
-      - type: notes
-        date_effective: 1999-12-08
-        message: ISO/TC 154 Chair will secure an active liaison with TC 215
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
-    identifier: 2
-
-    approvals:
-      - type: 
-        degree: 
-        message: Closed
-
-    actions:
-      - type: notes
-        date_effective: 1999-12-08
-        message: DIN will convert the 99 work programme from PDF to DOC format
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
-    identifier: 3
-
-    actions:
-      - type: notes
-        date_effective: 1999-12-08
-        message: ISO/TC 154 agreed that all comments to N321 – Compendium of Trade Facilitation Recommendations, should be forwarded to TC 154 Chair for him to forward them to UN/CEFACT.
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
-    identifier: 4
-
-    actions:
-      - type: notes
-        date_effective: 1999-12-08
-        message: ISO/TC 154 WG1 secretariat will forward the results of the processing of the comments to TS 16668 to TC 154 Secretary for distribution to the P members in line with resolution 179.
-
-  - dates:
-    start: 1999-12-07
-    end: 1999-12-08
-    subject: 
-    identifier: 5
-
-    actions:
-      - type: notes
-        date_effective: 1999-12-08
-        message: ISO/TC 154 secretary will recall that when P members are voting, L and O members have a right to comment.
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: action-1
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 1999-12-08
+  #       message: ISO/TC 154 Chair will secure an active liaison with TC 215
+  #
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: action-2
+  #
+  #   approvals:
+  #     - type: affirmative
+  #       degree: unanimous
+  #       message: Closed
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 1999-12-08
+  #       message: DIN will convert the 99 work programme from PDF to DOC format
+  #
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: action-3
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 1999-12-08
+  #       message: ISO/TC 154 agreed that all comments to N321 – Compendium of Trade Facilitation Recommendations, should be forwarded to TC 154 Chair for him to forward them to UN/CEFACT.
+  #
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: action-4
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 1999-12-08
+  #       message: ISO/TC 154 WG1 secretariat will forward the results of the processing of the comments to TS 16668 to TC 154 Secretary for distribution to the P members in line with resolution 179.
+  #
+  # - dates:
+  #     start: 1999-12-07
+  #     end: 1999-12-08
+  #   subject: ISO/TC 154
+  #   identifier: action-5
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 1999-12-08
+  #       message: ISO/TC 154 secretary will recall that when P members are voting, L and O members have a right to comment.

--- a/plenary/plenary-17.yaml
+++ b/plenary/plenary-17.yaml
@@ -71,6 +71,7 @@ resolutions:
   - dates:
       start: 2000-09-20
       end: 2000-09-21
+    subject: ISO/TC 154
     identifier: 185
 
     approvals:
@@ -86,19 +87,20 @@ resolutions:
 
           The editor is Mr Boesler (DIN, DE).
 
-  - dates:
-    start: 2000-09-20
-    end: 2000-09-21
-    identifier: 6
+  # - dates:
+  #     start: 2000-09-20
+  #     end: 2000-09-21
+  #   subject: ISO/TC 154
+  #   identifier: action-6
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 2000-09-21
+  #       message: The resulting document will be forwarded to the Secretariat of ISO/TC 154.
 
-    actions:
-      - type: notes
-        date_effective: 2000-09-21
-        message: The resulting document will be forwarded to the Secretariat of ISO/TC 154.
-
   - dates:
-    start: 2000-09-20
-    end: 2000-09-21
+      start: 2000-09-20
+      end: 2000-09-21
     subject: ISO/TC 154
     identifier: 186
 
@@ -148,6 +150,7 @@ resolutions:
 
           The task force members are: Mr Visser (NNI, NL, Convenor), Mr Crowley (US), Mr Vuilleumier (ISO/TC 154 Chairman) and Mr Bezos (ISO/TC 184 liaison).
 
+
   - dates:
       start: 2000-09-20
       end: 2000-09-21
@@ -162,7 +165,11 @@ resolutions:
     considerations:
       - type: identifying
         date_effective: 2000-09-21
-        message: identifying ISO7372 (UNTDED) as a key element in the set of ISO standards as listed in TC143N324 “Suite of ISO standards around the UN layout-key and UNTDED”, recognising MoU resolution 99/27, confirming the maintenance procedures of the standard as stated in ISO 7372 (UNTDED), section 2 (see TC154N339)
+        message: "identifying ISO7372 (UNTDED) as a key element in the set of ISO standards as listed in TC143N324 “Suite of ISO standards around the UN layout-key and UNTDED”"
+
+      - type: identifying
+        date_effective: 2000-09-21
+        message: "recognising MoU resolution 99/27, confirming the maintenance procedures of the standard as stated in ISO 7372 (UNTDED), section 2 (see TC154N339):"
 
       - type: noting
         date_effective: 2000-09-21
@@ -184,19 +191,9 @@ resolutions:
         date_effective: 2000-09-21
         message: considering that any revision to ISO7372 (UNTDED) requires to take into account both EDED and UNCL of UN/EDIFACT ;
 
-      - type: taking
+      - type: considering
         date_effective: 2000-09-21
         message: taking stock of the need for it to address the role of the BSR in relation to the revision of ISO7372 (UNTDED) ;
-
-      - type: noting
-        date_effective: 2000-09-21
-        message: |
-          BACKGROUND :
-          - Historically the UNTDED was first issued as the single, common repository of semantic concepts that are used in the paper environment, later also in EDI, with bridges (so called "topographical co-ordinates") to sectoral directories as CIMP of IATA, SAD of EC/EFTA, SWIFT and MAR of IMO ;
-          - the EDI developments, specially UN/EDIFACT, were based initially on this semantic concepts repository ISO7372 (UNTDED) ;
-          - over time, the concept of generic data element and coded qualifiers developed by UN/EDIFACT enforced the syntax dependence for expressing semantic concepts ;
-          - hence a semantic concept in UN/EDIFACT requires usually a combination of at least a data element along with a code value.
-
 
     actions:
       - type: resolves
@@ -206,6 +203,15 @@ resolutions:
       - type: resolves
         date_effective: 2000-09-21
         message: to present BSR and ISO 7372 (UNTDED) to EWG and discuss opportunities for cooperation with UN/EDIFACT.
+
+      - type: notes
+        date_effective: 2000-09-21
+        message: |
+          BACKGROUND :
+            - Historically the UNTDED was first issued as the single, common repository of semantic concepts that are used in the paper environment, later also in EDI, with bridges (so called "topographical co-ordinates") to sectoral directories as CIMP of IATA, SAD of EC/EFTA, SWIFT and MAR of IMO ;
+            - the EDI developments, specially UN/EDIFACT, were based initially on this semantic concepts repository ISO7372 (UNTDED) ;
+            - over time, the concept of generic data element and coded qualifiers developed by UN/EDIFACT enforced the syntax dependence for expressing semantic concepts ;
+            - hence a semantic concept in UN/EDIFACT requires usually a combination of at least a data element along with a code value.
 
 
   - dates:
@@ -317,21 +323,21 @@ resolutions:
         date_effective: 2000-09-21
         message: ISO/TC 154 resolves to hold its next meeting (18th) back-to-back before the EWG meeting in Europe, 2001-09 (date and place to be determined).
 
-  - dates:
-    start: 2000-09-20
-    end: 2000-09-21
-    subject: ISO/TC 154
-    identifier: action-7
-
-    approvals:
-      - type: affirmative
-        degree: unanimous
-        message: Adopted
-
-    actions:
-      - type: notes
-        date_effective: 2000-09-21
-        message: "The Secretary of JSWG to deliver to ISO/TC154 Chairman (for distribution as a TC154 document) an overview paper of the new 10 parts of ISO 9735 “EDIFACT – Application level syntax rules (Syntax version number: 4)” and time-plan for the publication of these 10 parts."
+  # - dates:
+  #     start: 2000-09-20
+  #     end: 2000-09-21
+  #   subject: ISO/TC 154
+  #   identifier: action-7
+  #
+  #   approvals:
+  #     - type: affirmative
+  #       degree: unanimous
+  #       message: Adopted
+  #
+  #   actions:
+  #     - type: notes
+  #       date_effective: 2000-09-21
+  #       message: "The Secretary of JSWG to deliver to ISO/TC154 Chairman (for distribution as a TC154 document) an overview paper of the new 10 parts of ISO 9735 “EDIFACT – Application level syntax rules (Syntax version number: 4)” and time-plan for the publication of these 10 parts."
 
 
   - dates:

--- a/plenary/plenary-17.yaml
+++ b/plenary/plenary-17.yaml
@@ -1,5 +1,5 @@
 metadata:
-  title: Resolutions/action items of the 17th meeting in Prague
+  title: Resolutions and action items of the ISO/TC154 17th meeting, Revision 1 2000-09-20/21, Prague, CZ.
   date:
     start: 2000-09-20
     end: 2000-09-21
@@ -83,12 +83,22 @@ resolutions:
         date_effective: 2000-09-21
         message: |
           ISO/TC 154 resolves to issue a Technical Corrigendum on ISO8440:1986, based on document TC154N316.
+
           The editor is Mr Boesler (DIN, DE).
 
+  - dates:
+    start: 2000-09-20
+    end: 2000-09-21
+    identifier: 6
+
+    actions:
+      - type: notes
+        date_effective: 2000-09-21
+        message: The resulting document will be forwarded to the Secretariat of ISO/TC 154.
 
   - dates:
-      start: 2000-09-20
-      end: 2000-09-21
+    start: 2000-09-20
+    end: 2000-09-21
     subject: ISO/TC 154
     identifier: 186
 
@@ -160,7 +170,11 @@ resolutions:
 
       - type: noting
         date_effective: 2000-09-21
-        message: "noting the TC154/WG 1 Resolution 13, which states : “ISO/TC154/WG1 appoints Mr Vuilleumier as liaison officer, to be assisted by deputies, to the EWG meeting to be held in Washington DC in 2001-03” ;"
+        message: and furthermore noting the will and need expressed in this Resolution 19 of EWG 2000-09, for a single, syntax independent repository of semantic concepts ;
+
+      - type: noting
+        date_effective: 2000-09-21
+        message: "noting the TC154/WG 1 (BSR) Resolution 13, which states : “ISO/TC154/WG1 appoints Mr Vuilleumier as liaison officer, to be assisted by deputies, to the EWG meeting to be held in Washington DC in 2001-03” ;"
 
       - type: recognising
         date_effective: 2000-09-21
@@ -176,16 +190,13 @@ resolutions:
 
       - type: noting
         date_effective: 2000-09-21
-        message: and furthermore noting the will and need expressed in Resolution 19 of EWG September 2000, for a single, syntax independent repository of semantic concepts ;
-
-      - type: noting
-        date_effective: 2000-09-21
         message: |
-          BACKGROUND:
-            - Historically the UNTDED was first issued as the single, common repository of semantic concepts that are used in the paper environment, later also in EDI, with bridges (so called "topographical co-ordinates") to sectoral directories as CIMP of IATA, SAD of EC/EFTA, SWIFT and MAR of IMO ;
-            - the EDI developments, specially UN/EDIFACT, were based initially on this semantic concepts repository ISO7372 (UNTDED) ;
-            - over time, the concept of generic data element and coded qualifiers developed by UN/EDIFACT enforced the syntax dependence for expressing semantic concepts ;
-            - hence a semantic concept in UN/EDIFACT requires usually a combination of at least a data element along with a code value.
+          BACKGROUND :
+          - Historically the UNTDED was first issued as the single, common repository of semantic concepts that are used in the paper environment, later also in EDI, with bridges (so called "topographical co-ordinates") to sectoral directories as CIMP of IATA, SAD of EC/EFTA, SWIFT and MAR of IMO ;
+          - the EDI developments, specially UN/EDIFACT, were based initially on this semantic concepts repository ISO7372 (UNTDED) ;
+          - over time, the concept of generic data element and coded qualifiers developed by UN/EDIFACT enforced the syntax dependence for expressing semantic concepts ;
+          - hence a semantic concept in UN/EDIFACT requires usually a combination of at least a data element along with a code value.
+
 
     actions:
       - type: resolves
@@ -195,6 +206,7 @@ resolutions:
       - type: resolves
         date_effective: 2000-09-21
         message: to present BSR and ISO 7372 (UNTDED) to EWG and discuss opportunities for cooperation with UN/EDIFACT.
+
 
   - dates:
       start: 2000-09-20
@@ -210,15 +222,15 @@ resolutions:
     actions:
       - type: resolves
         date_effective: 2000-09-21
-        message: "to further process the issue of a possible revision of ISO7372 (UNTDED) ;"
+        message: to further process the issue of a possible revision of ISO7372:1993 (UNTDED) ;
 
       - type: resolves
         date_effective: 2000-09-21
-        message: "to deliver its position by 2001-05-11."
+        message: to deliver its position by 2001-05-11.
 
       - type: notes
         date_effective: 2000-09-21
-        message: "This may result in a reactivation of the Joint UN-ECE/ISO Maintenance Agency (see document ISO/TC154N339)."
+        message: This may result in a reactivation of the Joint UN-ECE/ISO Maintenance Agency (see document ISO/TC154N339).
 
 
   - dates:
@@ -304,6 +316,22 @@ resolutions:
       - type: resolves
         date_effective: 2000-09-21
         message: ISO/TC 154 resolves to hold its next meeting (18th) back-to-back before the EWG meeting in Europe, 2001-09 (date and place to be determined).
+
+  - dates:
+    start: 2000-09-20
+    end: 2000-09-21
+    subject: ISO/TC 154
+    identifier: action-7
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: Adopted
+
+    actions:
+      - type: notes
+        date_effective: 2000-09-21
+        message: "The Secretary of JSWG to deliver to ISO/TC154 Chairman (for distribution as a TC154 document) an overview paper of the new 10 parts of ISO 9735 “EDIFACT – Application level syntax rules (Syntax version number: 4)” and time-plan for the publication of these 10 parts."
 
 
   - dates:

--- a/plenary/plenary-18.yaml
+++ b/plenary/plenary-18.yaml
@@ -1,0 +1,402 @@
+metadata:
+  title: Resolutions and action items of the ISO/TC 154 18th meeting 2001-09-05/07, Brussels, BE
+  date: 
+    start: 2001-09-05
+    end: 2001-09-07
+  source: ISO/TC 154
+
+resolutions:
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 197
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: ISO/TC 154 resolves to publish the document ISO/TC154/WG1 N22 Rev 2 (see document 154 N 377 add 1) as a standing document. Mr J-L Commo will finalize the document.
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    identifier: 198
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: appreciates
+        date_effective: 2001-09-07
+        message: ISO/TC 154 appreciates the demonstration of the “BSR tool” made by Mr Alain Chapdaniel during the meeting and thanks very much the French consortium for their valuable contribution.
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 199
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: |
+        ISO/TC 154 expresses strong interest in the possible use of the BSR tool. Therefore, TC 154 resolves to approach the French consortium to request that this tool may be made available for a trial arranged as follows :
+
+        a/ Participants to the trial : CH, FR, US, DE, AU, GB, YU, JP, CZ, CN, and ISO/TC68, ISO/TC184, EWG(T1), FIATA and WCO (see document 154 N 373: ISO/TC 154 18th meeting attendance list) ;
+
+        b/ Populating directory        and        contact person :
+        - ISO 7372:1993 (UNTDED)              Mr François Vuilleumier ;
+        - EDIFACT directories                 Ms Margaret Pemberton ;
+        - ebXML core components               Ms Mary K. Blantz ;
+        - G 7 data harmonisation group        Mr Thomas Morawietz ;
+        - ISO/TC 68                           Mr Frank Vandamme ; and
+        - ISO/TC 184 (STEP)                   Mr Alain Bezos ; and
+        - candidates BSUs                     Mr Hartmut Hermes.
+        These directories must be sent by 2001-09-20 to Mr Alain Chapdaniel ;
+
+        c/ Trial period :
+        - 2001-10-01 : starting of the trial ;
+        - 2002-03-08 : closing of the trial and delivery of a trial reports to TC 154 Chair ;
+        - 2002-04-30 : TC 154 Chair to circulate a summary report on the results of the trial to TC 154 Members for further processing.
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject:
+    identifier: 8
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: notes
+        date_effective: 2001-09-07
+        message: ISO/TC 154 notes that its WG 1 will organise a workshop, in Paris, on 2001-10-23 afternoon and 24 morning, and afternoon if necessary, (dates to be confirmed), to discuss the BSR tool and to make proposals on the BSR project.
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 200
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: |
+        ISO/TC 154 resolves to discontinue, at least for the time being, any development of new BSUs for the BSR. ISO/TC 154 recognises that there are empowered bodies within UN/CEFACT that are better resourced to do this work, and that any duplication of effort would be a waste of their limited resources.
+        This resolution will be reassessed at the next (19th) plenary meeting.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject:
+    identifier: 9
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: asks
+        date_effective: 2001-09-07
+        message: ISO/TC 154 asks the BSR consortium to deliver the latest results of the ISO/TC 154 project on the development of BSUs to the Core Components (cc) developers as input to their development work. This shall happen prior to the meetings of the Core Components developers in Rotterdam, starting on 2001-09-10.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 201
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: appreciates
+        date_effective: 2001-09-07
+        message: ISO/TC 154, considering action 9, will greatly appreciate to receive the results of the Core Components developers’ work.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject:
+    identifier: 202
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: |
+        ISO/TC 154 resolves to grant an International Liaison A status for :
+        - EFTA
+          liaison officer : Mr Knut Hermansen, EFTA Secretariat
+        - EWG (UN/EDIFACT Working Group)
+          liaison officer : Ms Margaret Pemberton, EWG/T1 chair
+        - CDWG (UN/CEFACT Code Working Group)
+          liaison officer : Mr David Dobbing, CDWG chair.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject:
+    identifier: 203
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: confirms
+        date_effective: 2001-09-07
+        message: ISO/TC 154 confirms ISO 6422:1985, [UN] Layout key for trade documents [UNLK], and ISO 8439:1990, “Forms design – Basic layout”.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject:
+    identifier: 204
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: ISO/TC 154 resolves to send the 2nd edition of ISO 9735:1998/1999 (i.e. : version 4 release 1) to ISO/CS for fast-tracking.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: ISO/TC 154 :
+    identifier: 205
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    considerations:
+      - type: recalling
+        date_effective: 2001-09-07
+        message: |
+        recalling the role and importance of international standards and that :
+        - when members from international organizations adopt international standards and harmonize their technical regulations worldwide, everybody stands to gain ;
+        - national legislative and regulatory work is simplified and accelerated when reference can be made to internationally agreed standards ;
+        - the vital role of international standards as the technical foundation for the global market is explicitly recognized in the World Trade Organization (WTO) Agreement on Technical Barriers to Trade ;
+
+      - type: recalling
+        date_effective: 2001-09-07
+        message: |
+        recalling the role of the IEC, ISO, ITU and UNECE Memorandum of Understanding on Electronic Business and that :
+        - coordinated standards are essential and that standards developed within the domain of each organization will be interoperable and technically consistent ;
+        - with a view to avoiding duplication of efforts, the standardization organizations will continue their technical cooperation to secure complementary and synergetic efforts ;
+        - there is a need to avoid confusion amongst users ;
+
+      - type: recognizing
+        date_effective: 2001-09-07
+        message: recognizing the need for a single global business semantics repository for the development of e-business applications ;
+
+      - type: recognizing
+        date_effective: 2001-09-07
+        message: recognizing the role of ISO 7372 and recalling ISO/TC 154 Resolutions 189 and 190 (see above) on a possible revision of ISO 7372 in cooperation with relevant bodies ;
+
+      - type: acknowledging
+        date_effective: 2001-09-07
+        message: acknowledging the work done by the UN/EDIFACT Working group (EWG) since 1993 and other works, such as the WCO/G 7 Customs Harmonization Initiative based on ISO 7372:1993 ; and
+
+      - type: recognizing
+        date_effective: 2001-09-07
+        message: recognizing that ISO 7372 should be inclusive of the various sectors resulting in a common set of basic semantic elements and resolving the harmonization of the semantics when required ;
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: to initiate an upward compatible revision of ISO 7372:1993, with the next version available by 2003 ;
+
+      - type: resolves
+        date_effective: 2001-09-07
+        message: | 
+        to reactivate the ISO 7372 Maintenance Agency (see document 154 N 339), by establishing a Task Team chaired by Mr François Vuilleumier (ISO/TC 154 Chair) and consisting of : Mr Dietmar Jost (WCO), Mr David Dobbing (CDWG Chair), Mr Sandro Consoli (FIATA), Ms Sophie Clivio (ISO/CS), Mr Claude Chiaramonti (ISO/TC 154/WG 1 Convenor), Mr Frank Vandamme (ISO/TC 68 ; person to be confirmed), Mr Jean Kubler (UNECE Secretariat) and Ms Margaret Pemberton (EWG/T1 Chair), mandated to :
+        - develop by 2001-11-22 a concept document that describes the vision that supports the revision of ISO 7372, the strategy and a workplan. The document should take into account the UNTDID (UN/EDIFACT) and related work, agreed definitions to be used and issues to be resolved ;
+        - submit the document to ISO/TC 154 for comments for a review period of 1 month and reconcile the comments received for approval by ISO/TC 154 members ;
+        - submitting the approved document to the ISO 7372 Maintenance Agency (MA) for implementation, with an invitation letter for a first meeting of the ISO 7372 MA (see Resolution 208).
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 206
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: ISO/TC 154 resolves to request ISO/TMB to put ISO 8601:2000, “Representation of dates and times”, into the public domain.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 10
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: ISO/TC 154 Chair will inform Mr Louis Visser (ISO 8601 editor) of Resolution 206, thanking him for his excellent work.
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 207
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: establishes
+        date_effective: 2001-09-07
+        message: |
+        ISO/TC 154 establishes a Project Team in charge of further work on ISO/NP 22208 “Rules for the operation of EDI/EC registration authorities”, consisting of :
+        - Mr Alain Thiénot (Edira), Project leader,
+        - Ms Éva Imre (HU),
+        - Mr Hartmut Hermes (DE),
+        - Mr Louis Visser (NL),
+        - Mr Petr Wallenfels (CZ),
+        - Mr Otto Mueller (CH, Edira Chair),
+        - Ms Anna Wadsworth (BSI, ISO 6523 Registration Authority),
+        - [name to be provided] (ISO/TC 68),
+        - [name to be provided] (ISO/IEC JTC 1/SC 32),and
+        - [name to be provided] (ANSI ASC X12).
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 11
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: notes
+        date_effective: 2001-09-07
+        message: ISO/TC 154 Chair will issue the draft of ISO/CD22208-1 as document 154 N 381.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 208
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: ISO/TC 154 resolves to organize a meeting of ISO 7372 MA (see resolution 205). The meeting will take place in Geneva (CH), in the period of 2002-03-12 afternoon to 2002-03-15 morning.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 209
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: resolves
+        date_effective: 2001-09-07
+        message: ISO/TC 154 resolves to hold its next meeting (19th) in Geneva (CH), on 2002-03-15 afternoon.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 210
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: thanks
+        date_effective: 2001-09-07
+        message: ISO/TC 154 thanks Mr François Vuilleumier for his wise and efficient chairmanship.
+
+
+  - dates:
+    start: 2001-09-05
+    end: 2001-09-07
+    subject: 
+    identifier: 211
+
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        message: adopted
+
+    actions:
+      - type: thanks
+        date_effective: 2001-09-07
+        message: ISO/TC 154 thanks World Customs Organization and Mr Dietmar Jost, for hosting the meeting and for the excellent arrangement.

--- a/plenary/plenary-18.yaml
+++ b/plenary/plenary-18.yaml
@@ -1,15 +1,15 @@
 metadata:
-  title: Resolutions and action items of the ISO/TC 154 18th meeting 2001-09-05/07, Brussels, BE
-  date: 
+  title: Resolutions and action items of the ISO/TC 154 18th meeting 2001-09-05/07, Brussels, BE
+  date:
     start: 2001-09-05
     end: 2001-09-07
   source: ISO/TC 154
 
 resolutions:
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 197
 
     approvals:
@@ -20,11 +20,11 @@ resolutions:
     actions:
       - type: resolves
         date_effective: 2001-09-07
-        message: ISO/TC 154 resolves to publish the document ISO/TC154/WG1 N22 Rev 2 (see document 154 N 377 add 1) as a standing document. Mr J-L Commo will finalize the document.
+        message: ISO/TC 154 resolves to publish the document ISO/TC154/WG1 N22 Rev 2 (see document 154 N 377 add 1) as a standing document. Mr J-L Commo will finalize the document.
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
+      start: 2001-09-05
+      end: 2001-09-07
     identifier: 198
 
     approvals:
@@ -35,12 +35,12 @@ resolutions:
     actions:
       - type: appreciates
         date_effective: 2001-09-07
-        message: ISO/TC 154 appreciates the demonstration of the “BSR tool” made by Mr Alain Chapdaniel during the meeting and thanks very much the French consortium for their valuable contribution.
+        message: ISO/TC 154 appreciates the demonstration of the “BSR tool” made by Mr Alain Chapdaniel during the meeting and thanks very much the French consortium for their valuable contribution.
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 199
 
     approvals:
@@ -48,33 +48,40 @@ resolutions:
         degree: unanimous
         message: adopted
 
+    considerations:
+      - type: considering
+        date_effective:
+          start: 1999-12-07
+          end: 1999-12-08
+        message: ISO/TC 154 expresses strong interest in the possible use of the BSR tool.
+
     actions:
       - type: resolves
         date_effective: 2001-09-07
         message: |
-        ISO/TC 154 expresses strong interest in the possible use of the BSR tool. Therefore, TC 154 resolves to approach the French consortium to request that this tool may be made available for a trial arranged as follows :
+          Therefore, TC 154 resolves to approach the French consortium to request that this tool may be made available for a trial arranged as follows :
 
-        a/ Participants to the trial : CH, FR, US, DE, AU, GB, YU, JP, CZ, CN, and ISO/TC68, ISO/TC184, EWG(T1), FIATA and WCO (see document 154 N 373: ISO/TC 154 18th meeting attendance list) ;
+          a/ Participants to the trial : CH, FR, US, DE, AU, GB, YU, JP, CZ, CN, and ISO/TC68, ISO/TC184, EWG(T1), FIATA and WCO (see document 154 N 373: ISO/TC 154 18th meeting attendance list) ;
 
-        b/ Populating directory        and        contact person :
-        - ISO 7372:1993 (UNTDED)              Mr François Vuilleumier ;
-        - EDIFACT directories                 Ms Margaret Pemberton ;
-        - ebXML core components               Ms Mary K. Blantz ;
-        - G 7 data harmonisation group        Mr Thomas Morawietz ;
-        - ISO/TC 68                           Mr Frank Vandamme ; and
-        - ISO/TC 184 (STEP)                   Mr Alain Bezos ; and
-        - candidates BSUs                     Mr Hartmut Hermes.
-        These directories must be sent by 2001-09-20 to Mr Alain Chapdaniel ;
+          b/ Populating directory        and        contact person :
+          - ISO 7372:1993 (UNTDED)              Mr François Vuilleumier ;
+          - EDIFACT directories                 Ms Margaret Pemberton ;
+          - ebXML core components               Ms Mary K. Blantz ;
+          - G 7 data harmonisation group        Mr Thomas Morawietz ;
+          - ISO/TC 68                           Mr Frank Vandamme ; and
+          - ISO/TC 184 (STEP)                   Mr Alain Bezos ; and
+          - candidates BSUs                     Mr Hartmut Hermes.
+          These directories must be sent by 2001-09-20 to Mr Alain Chapdaniel ;
 
-        c/ Trial period :
-        - 2001-10-01 : starting of the trial ;
-        - 2002-03-08 : closing of the trial and delivery of a trial reports to TC 154 Chair ;
-        - 2002-04-30 : TC 154 Chair to circulate a summary report on the results of the trial to TC 154 Members for further processing.
+          c/ Trial period :
+          - 2001-10-01 : starting of the trial ;
+          - 2002-03-08 : closing of the trial and delivery of a trial reports to TC 154 Chair ;
+          - 2002-04-30 : TC 154 Chair to circulate a summary report on the results of the trial to TC 154 Members for further processing.
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject:
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 8
 
     approvals:
@@ -85,12 +92,12 @@ resolutions:
     actions:
       - type: notes
         date_effective: 2001-09-07
-        message: ISO/TC 154 notes that its WG 1 will organise a workshop, in Paris, on 2001-10-23 afternoon and 24 morning, and afternoon if necessary, (dates to be confirmed), to discuss the BSR tool and to make proposals on the BSR project.
+        message: ISO/TC 154 notes that its WG 1 will organise a workshop, in Paris, on 2001-10-23 afternoon and 24 morning, and afternoon if necessary, (dates to be confirmed), to discuss the BSR tool and to make proposals on the BSR project.
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 200
 
     approvals:
@@ -102,14 +109,14 @@ resolutions:
       - type: resolves
         date_effective: 2001-09-07
         message: |
-        ISO/TC 154 resolves to discontinue, at least for the time being, any development of new BSUs for the BSR. ISO/TC 154 recognises that there are empowered bodies within UN/CEFACT that are better resourced to do this work, and that any duplication of effort would be a waste of their limited resources.
-        This resolution will be reassessed at the next (19th) plenary meeting.
+          ISO/TC 154 resolves to discontinue, at least for the time being, any development of new BSUs for the BSR. ISO/TC 154 recognises that there are empowered bodies within UN/CEFACT that are better resourced to do this work, and that any duplication of effort would be a waste of their limited resources.
+          This resolution will be reassessed at the next (19th) plenary meeting.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject:
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 9
 
     approvals:
@@ -120,13 +127,13 @@ resolutions:
     actions:
       - type: asks
         date_effective: 2001-09-07
-        message: ISO/TC 154 asks the BSR consortium to deliver the latest results of the ISO/TC 154 project on the development of BSUs to the Core Components (cc) developers as input to their development work. This shall happen prior to the meetings of the Core Components developers in Rotterdam, starting on 2001-09-10.
+        message: ISO/TC 154 asks the BSR consortium to deliver the latest results of the ISO/TC 154 project on the development of BSUs to the Core Components (cc) developers as input to their development work. This shall happen prior to the meetings of the Core Components developers in Rotterdam, starting on 2001-09-10.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 201
 
     approvals:
@@ -137,13 +144,13 @@ resolutions:
     actions:
       - type: appreciates
         date_effective: 2001-09-07
-        message: ISO/TC 154, considering action 9, will greatly appreciate to receive the results of the Core Components developers’ work.
+        message: ISO/TC 154, considering action 9, will greatly appreciate to receive the results of the Core Components developers’ work.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject:
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 202
 
     approvals:
@@ -155,19 +162,19 @@ resolutions:
       - type: resolves
         date_effective: 2001-09-07
         message: |
-        ISO/TC 154 resolves to grant an International Liaison A status for :
-        - EFTA
-          liaison officer : Mr Knut Hermansen, EFTA Secretariat
-        - EWG (UN/EDIFACT Working Group)
-          liaison officer : Ms Margaret Pemberton, EWG/T1 chair
-        - CDWG (UN/CEFACT Code Working Group)
-          liaison officer : Mr David Dobbing, CDWG chair.
+          ISO/TC 154 resolves to grant an International Liaison A status for :
+          - EFTA
+            liaison officer : Mr Knut Hermansen, EFTA Secretariat
+          - EWG (UN/EDIFACT Working Group)
+            liaison officer : Ms Margaret Pemberton, EWG/T1 chair
+          - CDWG (UN/CEFACT Code Working Group)
+            liaison officer : Mr David Dobbing, CDWG chair.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject:
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 203
 
     approvals:
@@ -178,13 +185,13 @@ resolutions:
     actions:
       - type: confirms
         date_effective: 2001-09-07
-        message: ISO/TC 154 confirms ISO 6422:1985, [UN] Layout key for trade documents [UNLK], and ISO 8439:1990, “Forms design – Basic layout”.
+        message: ISO/TC 154 confirms ISO 6422:1985, [UN] Layout key for trade documents [UNLK], and ISO 8439:1990, “Forms design – Basic layout”.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject:
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 204
 
     approvals:
@@ -195,13 +202,13 @@ resolutions:
     actions:
       - type: resolves
         date_effective: 2001-09-07
-        message: ISO/TC 154 resolves to send the 2nd edition of ISO 9735:1998/1999 (i.e. : version 4 release 1) to ISO/CS for fast-tracking.
+        message: "ISO/TC 154 resolves to send the 2nd edition of ISO 9735:1998/1999 (i.e. : version 4 release 1) to ISO/CS for fast-tracking."
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: ISO/TC 154 :
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 205
 
     approvals:
@@ -213,53 +220,53 @@ resolutions:
       - type: recalling
         date_effective: 2001-09-07
         message: |
-        recalling the role and importance of international standards and that :
-        - when members from international organizations adopt international standards and harmonize their technical regulations worldwide, everybody stands to gain ;
-        - national legislative and regulatory work is simplified and accelerated when reference can be made to internationally agreed standards ;
-        - the vital role of international standards as the technical foundation for the global market is explicitly recognized in the World Trade Organization (WTO) Agreement on Technical Barriers to Trade ;
+          recalling the role and importance of international standards and that :
+          - when members from international organizations adopt international standards and harmonize their technical regulations worldwide, everybody stands to gain ;
+          - national legislative and regulatory work is simplified and accelerated when reference can be made to internationally agreed standards ;
+          - the vital role of international standards as the technical foundation for the global market is explicitly recognized in the World Trade Organization (WTO) Agreement on Technical Barriers to Trade ;
 
       - type: recalling
         date_effective: 2001-09-07
         message: |
-        recalling the role of the IEC, ISO, ITU and UNECE Memorandum of Understanding on Electronic Business and that :
-        - coordinated standards are essential and that standards developed within the domain of each organization will be interoperable and technically consistent ;
-        - with a view to avoiding duplication of efforts, the standardization organizations will continue their technical cooperation to secure complementary and synergetic efforts ;
-        - there is a need to avoid confusion amongst users ;
+          recalling the role of the IEC, ISO, ITU and UNECE Memorandum of Understanding on Electronic Business and that :
+          - coordinated standards are essential and that standards developed within the domain of each organization will be interoperable and technically consistent ;
+          - with a view to avoiding duplication of efforts, the standardization organizations will continue their technical cooperation to secure complementary and synergetic efforts ;
+          - there is a need to avoid confusion amongst users ;
 
       - type: recognizing
         date_effective: 2001-09-07
-        message: recognizing the need for a single global business semantics repository for the development of e-business applications ;
+        message: recognizing the need for a single global business semantics repository for the development of e-business applications ;
 
       - type: recognizing
         date_effective: 2001-09-07
-        message: recognizing the role of ISO 7372 and recalling ISO/TC 154 Resolutions 189 and 190 (see above) on a possible revision of ISO 7372 in cooperation with relevant bodies ;
+        message: recognizing the role of ISO 7372 and recalling ISO/TC 154 Resolutions 189 and 190 (see above) on a possible revision of ISO 7372 in cooperation with relevant bodies ;
 
       - type: acknowledging
         date_effective: 2001-09-07
-        message: acknowledging the work done by the UN/EDIFACT Working group (EWG) since 1993 and other works, such as the WCO/G 7 Customs Harmonization Initiative based on ISO 7372:1993 ; and
+        message: acknowledging the work done by the UN/EDIFACT Working group (EWG) since 1993 and other works, such as the WCO/G 7 Customs Harmonization Initiative based on ISO 7372:1993 ; and
 
       - type: recognizing
         date_effective: 2001-09-07
-        message: recognizing that ISO 7372 should be inclusive of the various sectors resulting in a common set of basic semantic elements and resolving the harmonization of the semantics when required ;
+        message: recognizing that ISO 7372 should be inclusive of the various sectors resulting in a common set of basic semantic elements and resolving the harmonization of the semantics when required ;
 
     actions:
       - type: resolves
         date_effective: 2001-09-07
-        message: to initiate an upward compatible revision of ISO 7372:1993, with the next version available by 2003 ;
+        message: to initiate an upward compatible revision of ISO 7372:1993, with the next version available by 2003 ;
 
       - type: resolves
         date_effective: 2001-09-07
-        message: | 
-        to reactivate the ISO 7372 Maintenance Agency (see document 154 N 339), by establishing a Task Team chaired by Mr François Vuilleumier (ISO/TC 154 Chair) and consisting of : Mr Dietmar Jost (WCO), Mr David Dobbing (CDWG Chair), Mr Sandro Consoli (FIATA), Ms Sophie Clivio (ISO/CS), Mr Claude Chiaramonti (ISO/TC 154/WG 1 Convenor), Mr Frank Vandamme (ISO/TC 68 ; person to be confirmed), Mr Jean Kubler (UNECE Secretariat) and Ms Margaret Pemberton (EWG/T1 Chair), mandated to :
-        - develop by 2001-11-22 a concept document that describes the vision that supports the revision of ISO 7372, the strategy and a workplan. The document should take into account the UNTDID (UN/EDIFACT) and related work, agreed definitions to be used and issues to be resolved ;
-        - submit the document to ISO/TC 154 for comments for a review period of 1 month and reconcile the comments received for approval by ISO/TC 154 members ;
-        - submitting the approved document to the ISO 7372 Maintenance Agency (MA) for implementation, with an invitation letter for a first meeting of the ISO 7372 MA (see Resolution 208).
+        message: |
+          to reactivate the ISO 7372 Maintenance Agency (see document 154 N 339), by establishing a Task Team chaired by Mr François Vuilleumier (ISO/TC 154 Chair) and consisting of : Mr Dietmar Jost (WCO), Mr David Dobbing (CDWG Chair), Mr Sandro Consoli (FIATA), Ms Sophie Clivio (ISO/CS), Mr Claude Chiaramonti (ISO/TC 154/WG 1 Convenor), Mr Frank Vandamme (ISO/TC 68 ; person to be confirmed), Mr Jean Kubler (UNECE Secretariat) and Ms Margaret Pemberton (EWG/T1 Chair), mandated to :
+          - develop by 2001-11-22 a concept document that describes the vision that supports the revision of ISO 7372, the strategy and a workplan. The document should take into account the UNTDID (UN/EDIFACT) and related work, agreed definitions to be used and issues to be resolved ;
+          - submit the document to ISO/TC 154 for comments for a review period of 1 month and reconcile the comments received for approval by ISO/TC 154 members ;
+          - submitting the approved document to the ISO 7372 Maintenance Agency (MA) for implementation, with an invitation letter for a first meeting of the ISO 7372 MA (see Resolution 208).
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 206
 
     approvals:
@@ -270,13 +277,13 @@ resolutions:
     actions:
       - type: resolves
         date_effective: 2001-09-07
-        message: ISO/TC 154 resolves to request ISO/TMB to put ISO 8601:2000, “Representation of dates and times”, into the public domain.
+        message: ISO/TC 154 resolves to request ISO/TMB to put ISO 8601:2000, “Representation of dates and times”, into the public domain.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 10
 
     approvals:
@@ -287,12 +294,12 @@ resolutions:
     actions:
       - type: resolves
         date_effective: 2001-09-07
-        message: ISO/TC 154 Chair will inform Mr Louis Visser (ISO 8601 editor) of Resolution 206, thanking him for his excellent work.
+        message: ISO/TC 154 Chair will inform Mr Louis Visser (ISO 8601 editor) of Resolution 206, thanking him for his excellent work.
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 207
 
     approvals:
@@ -304,23 +311,23 @@ resolutions:
       - type: establishes
         date_effective: 2001-09-07
         message: |
-        ISO/TC 154 establishes a Project Team in charge of further work on ISO/NP 22208 “Rules for the operation of EDI/EC registration authorities”, consisting of :
-        - Mr Alain Thiénot (Edira), Project leader,
-        - Ms Éva Imre (HU),
-        - Mr Hartmut Hermes (DE),
-        - Mr Louis Visser (NL),
-        - Mr Petr Wallenfels (CZ),
-        - Mr Otto Mueller (CH, Edira Chair),
-        - Ms Anna Wadsworth (BSI, ISO 6523 Registration Authority),
-        - [name to be provided] (ISO/TC 68),
-        - [name to be provided] (ISO/IEC JTC 1/SC 32),and
-        - [name to be provided] (ANSI ASC X12).
+          ISO/TC 154 establishes a Project Team in charge of further work on ISO/NP 22208 “Rules for the operation of EDI/EC registration authorities”, consisting of :
+          - Mr Alain Thiénot (Edira), Project leader,
+          - Ms Éva Imre (HU),
+          - Mr Hartmut Hermes (DE),
+          - Mr Louis Visser (NL),
+          - Mr Petr Wallenfels (CZ),
+          - Mr Otto Mueller (CH, Edira Chair),
+          - Ms Anna Wadsworth (BSI, ISO 6523 Registration Authority),
+          - [name to be provided] (ISO/TC 68),
+          - [name to be provided] (ISO/IEC JTC 1/SC 32),and
+          - [name to be provided] (ANSI ASC X12).
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 11
 
     approvals:
@@ -331,13 +338,13 @@ resolutions:
     actions:
       - type: notes
         date_effective: 2001-09-07
-        message: ISO/TC 154 Chair will issue the draft of ISO/CD22208-1 as document 154 N 381.
+        message: ISO/TC 154 Chair will issue the draft of ISO/CD22208-1 as document 154 N 381.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 208
 
     approvals:
@@ -348,13 +355,13 @@ resolutions:
     actions:
       - type: resolves
         date_effective: 2001-09-07
-        message: ISO/TC 154 resolves to organize a meeting of ISO 7372 MA (see resolution 205). The meeting will take place in Geneva (CH), in the period of 2002-03-12 afternoon to 2002-03-15 morning.
+        message: ISO/TC 154 resolves to organize a meeting of ISO 7372 MA (see resolution 205). The meeting will take place in Geneva (CH), in the period of 2002-03-12 afternoon to 2002-03-15 morning.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 209
 
     approvals:
@@ -365,13 +372,13 @@ resolutions:
     actions:
       - type: resolves
         date_effective: 2001-09-07
-        message: ISO/TC 154 resolves to hold its next meeting (19th) in Geneva (CH), on 2002-03-15 afternoon.
+        message: ISO/TC 154 resolves to hold its next meeting (19th) in Geneva (CH), on 2002-03-15 afternoon.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 210
 
     approvals:
@@ -382,13 +389,13 @@ resolutions:
     actions:
       - type: thanks
         date_effective: 2001-09-07
-        message: ISO/TC 154 thanks Mr François Vuilleumier for his wise and efficient chairmanship.
+        message: ISO/TC 154 thanks Mr François Vuilleumier for his wise and efficient chairmanship.
 
 
   - dates:
-    start: 2001-09-05
-    end: 2001-09-07
-    subject: 
+      start: 2001-09-05
+      end: 2001-09-07
+    subject: ISO/TC 154
     identifier: 211
 
     approvals:
@@ -399,4 +406,4 @@ resolutions:
     actions:
       - type: thanks
         date_effective: 2001-09-07
-        message: ISO/TC 154 thanks World Customs Organization and Mr Dietmar Jost, for hosting the meeting and for the excellent arrangement.
+        message: ISO/TC 154 thanks World Customs Organization and Mr Dietmar Jost, for hosting the meeting and for the excellent arrangement.


### PR DESCRIPTION
16th plenary meeting
--------------------------
- I'm not sure how the "Addressed" status should be written. I've set in the "approvals", without a "type" and "degree", but with "message: Addressed".
- Items which only have a message such as "See resolution (...)" are written as "action" items with type "notes". 
- Action items are written with type "notes". The only one with the status is written without a "type" and "degree", but with "message: Closed".


17th plenary meeting:
--------------------------
- Messages for the items which don't have Res.#, rather Act.# are written as "action" items with type "notes". 
- Resolution 189: first part is written as "considerations", while the second one (starting from "resolves:") is written as "actions". I've set the type "notes" for the "BACKGROUND".
- I'm not sure if the "date_effective" should be 2000-12-14 or 2000-09-21. Currently, 2000-09-21 is set.


18th plenary meeting:
--------------------------
- Message for the item which doesn't have Res.#, rather Act.# is written as "action" item with type "notes". 

If anything needs to be changed, please let me know.